### PR TITLE
[CLEANUP] Automatically use version number from VERSION file in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## x.y.z (unreleased)
 
 ### Added
-- Add a code of conduct 
+- Automatically use the version number from the VERSION file in the gemspec
+  ([#32](https://github.com/braingourmets/currency_select/pull/32))
+- Add a code of conduct
   ([#25](https://github.com/braingourmets/currency_select/pull/25))
 
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+version = File.read(File.expand_path('../VERSION', __FILE__)).strip
+
 Gem::Specification.new do |s|
   s.name = 'currency_select'
   s.summary = 'Currency select plugin for Rails'
-  s.version = '0.1.5'
+  s.version = version
   s.license = 'MIT'
 
   s.homepage = 'https://github.com/braingourmets/currency_select'


### PR DESCRIPTION
This allows use to have the current version number in exactly one place,
not two.