### PR TITLE
[TASK] Require only supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2.10
   - 2.3.7
   - 2.4.4
 
@@ -26,15 +23,3 @@ script:
 matrix:
   fast_finish: true
   exclude:
-    - gemfile: Gemfile
-      rvm: 2.0.0
-    - gemfile: Gemfile
-      rvm: 2.1
-    - gemfile: gemfiles/Gemfile.rails-5-0
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile.rails-5-0
-      rvm: 2.1
-    - gemfile: gemfiles/Gemfile.rails-5-1
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile.rails-5-1
-      rvm: 2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,23 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-
 ## x.y.z (unreleased)
 
 ### Added
 
-
 ### Changed
-
 
 ### Deprecated
 
-
 ### Removed
-
+- Drop support for Ruby < 2.3
+  ([#48](https://github.com/braingourmets/currency_select/pull/48))
 
 ### Fixed
 - Fix value call on Rails 5.2
   ([#47](https://github.com/braingourmets/currency_select/pull/47))
 
 ### Security
-
-
 
 ## 0.2.0
 
@@ -34,11 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add a code of conduct
   ([#25](https://github.com/braingourmets/currency_select/pull/25))
 
-
 ### Changed
 - Mark all Ruby files as frozen_string_literal: true
   ([#31](https://github.com/braingourmets/currency_select/pull/31))
-
 
 ### Deprecated
 - Support for Rails < 5.0.0 will be removed in version 2.0.0.
@@ -46,13 +39,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support for Ruby < 2.2.2 will be removed in version 2.0.0.
 - Support for Ruby < 2.0.0 will be removed in version 1.0.0.
 
-
 ### Removed
 - Remove pre-Rails-4.0-specific code
   ([#38](https://github.com/braingourmets/currency_select/pull/38))
 - Drop Jeweler
   ([#28](https://github.com/braingourmets/currency_select/pull/28))
-
 
 ### Fixed
 - Add ActionView as explicit dependency

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
   s.version = version
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.3.0'
+
   s.homepage = 'https://github.com/braingourmets/currency_select'
   s.authors = ['Trond Arve Nordheim', 'Oliver Klee']
   s.email = 'o.klee@braingourmets.com'


### PR DESCRIPTION
Support for Ruby 2.2 has ended on June 20th, 2018. So this gem
now requires Ruby >= 2.3.