### PR TITLE
Adding extra info on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Add the following to your Gemfile:
 
     currency_select("user", "currency")
 
+### form_for example
+```
+<%= f.currency_select(:currency, ["USD", "EUR", "CAD"], {}, {class: "form-control"}) -%>
+```
 
 ## Contributing to this project
 


### PR DESCRIPTION
priority_currencies don't need to be defined and may cause in some cases confusion.