### PR TITLE
[TASK] Drop support for Ruby < 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.8
   - 2.4.7
   - 2.5.6
   - 2.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby < 2.4
+  ([#61](https://github.com/braingourmets/currency_select/pull/61))
 - Drop support for Ruby < 2.3
   ([#48](https://github.com/braingourmets/currency_select/pull/48))
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = version
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.homepage = 'https://github.com/braingourmets/currency_select'
   s.authors = ['Trond Arve Nordheim', 'Oliver Klee']
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'actionview', '>= 4.2.0', '< 6.0'
   s.add_runtime_dependency 'money', '~> 6.0'
 
-  s.add_development_dependency 'rspec-rails', '~> 3.8'
+  s.add_development_dependency 'rspec-rails', '~> 3.8.2'
 end


### PR DESCRIPTION
Ruby 2.3 has reached its end of life:
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/