### PR TITLE
[TASK] Drop support for Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ rvm:
 
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile.rails-5-1
   - gemfiles/Gemfile.rails-5-2
   - gemfiles/Gemfile.rails-6-0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop support for Rails < 5.2
+  ([#65](https://github.com/braingourmets/currency_select/pull/65))
 
 ### Fixed
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = %w[lib/currency_select.rb rails/init.rb CHANGELOG.md CODE_OF_CONDUCT.md currency_select.gemspec Gemfile LICENSE Rakefile README.md VERSION]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_runtime_dependency 'actionview', '>= 5.1.0', '< 6.1'
+  s.add_runtime_dependency 'actionview', '>= 5.2.0', '< 6.1'
   s.add_runtime_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.8.2'

--- a/gemfiles/Gemfile.rails-5-1
+++ b/gemfiles/Gemfile.rails-5-1
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'http://rubygems.org'
-
-gem 'rails', '~> 5.1.0'
-
-gemspec path: '../'

--- a/gemfiles/Gemfile.rails-5-2
+++ b/gemfiles/Gemfile.rails-5-2
@@ -2,6 +2,6 @@
 
 source 'http://rubygems.org'
 
-gem 'rails', '~> 5.2.0'
+gem 'rails', '~> 5.2.4.1'
 
 gemspec path: '../'

--- a/gemfiles/Gemfile.rails-6-0
+++ b/gemfiles/Gemfile.rails-6-0
@@ -2,6 +2,6 @@
 
 source 'http://rubygems.org'
 
-gem 'rails', '~> 6.0.0'
+gem 'rails', '~> 6.0.2.1'
 
 gemspec path: '../'


### PR DESCRIPTION
Rails 5.1 has reached its end of life, and only Rails 5.2 and 6.0 are
supported now.