### PR TITLE
[CLEANUP] Fix notices in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: linux
 
+dist: bionic
+
 language: ruby
 
 cache: bundler
@@ -21,7 +23,7 @@ install:
 script:
   - bundle exec rspec spec/
 
-matrix:
+jobs:
   fast_finish: true
   exclude:
     - gemfile: gemfiles/Gemfile.rails-6-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Fix warnings in the `.travis.yml`
-  ([#67](https://github.com/braingourmets/currency_select/pull/67))
+  ([#67](https://github.com/braingourmets/currency_select/pull/67),
+  [#69](https://github.com/braingourmets/currency_select/pull/69))
 
 ### Security
 


### PR DESCRIPTION
- explicitly set the Linux distribution
- replace the alias `matrix` with `jobs`