### PR TITLE
[TASK] Drop support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.4.10
   - 2.5.8
   - 2.6.6
   - 2.7.1
@@ -25,6 +24,3 @@ script:
 
 jobs:
   fast_finish: true
-  exclude:
-    - gemfile: gemfiles/Gemfile.rails-6-0
-      rvm: 2.4.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby 2.4
+  ([#70](https://github.com/braingourmets/currency_select/pull/70))
 - Drop support for Rails < 5.2
   ([#65](https://github.com/braingourmets/currency_select/pull/65))
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = version
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.homepage = 'https://github.com/braingourmets/currency_select'
   s.authors = ['Trond Arve Nordheim', 'Oliver Klee']


### PR DESCRIPTION
Ruby 2.4 has reached its end of life.
https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/