### PR TITLE
Include Rails 6.1 in version support

### DIFF
--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   ]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_runtime_dependency 'actionview', '>= 5.2.0', '< 6.1'
+  s.add_runtime_dependency 'actionview', '>= 5.2.0', '< 6.2'
   s.add_runtime_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 4.0.0'


### PR DESCRIPTION
Bumped actionview dependency to `< 6.2` in order to support Rails 6.1.