### PR TITLE
[BUGFIX] Use a maintained action for installing Ruby for the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 'Set up Ruby'
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0.0'
       - name: 'Check the environment'
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 'Set up Ruby'
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '${{ matrix.ruby }}'
       - name: 'Check the environment'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add support for Ruby 2.7 (#66)
 
 ### Changed
-- Switch the CI from Travis to GitHub Actions (#80)
+- Switch the CI from Travis to GitHub Actions (#80, #85)
 - Upgrade RSpec and RSpec-Rails (#71)
 - Update the Ruby versions on Travis CI (#68)
 


### PR DESCRIPTION
`ruby/setup-ruby` is the better action to use for installing Ruby
in GitHub Actions (particularly for more recent Ruby versions);
`actions/setup-ruby` is not.