### PR TITLE
[TASK] Limit the runtime of the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   static-analysis:
     name: 'Static analysis'
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
       - name: 'Set up Ruby'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: 'Publish to RubyGems'
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This keeps stuck jobs from unnecessarily hogging CI resources.