### PR TITLE
[TASK] Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,15 +59,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '6.0', 'ruby': '2.7.8' }
           - { 'rails': '6.0', 'ruby': '3.0.6' }
           - { 'rails': '6.0', 'ruby': '3.1.4' }
           - { 'rails': '6.0', 'ruby': '3.2.2' }
-          - { 'rails': '6.1', 'ruby': '2.7.8' }
           - { 'rails': '6.1', 'ruby': '3.0.6' }
           - { 'rails': '6.1', 'ruby': '3.1.4' }
           - { 'rails': '6.1', 'ruby': '3.2.2' }
-          - { 'rails': '7.0', 'ruby': '2.7.8' }
           - { 'rails': '7.0', 'ruby': '3.0.6' }
           - { 'rails': '7.0', 'ruby': '3.1.4' }
           - { 'rails': '7.0', 'ruby': '3.2.2' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   TargetRailsVersion: 6.0
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 - Drop support for Rails 5.2 (#112)
-- Drop support for Ruby 2.6 (#111)
+- Drop support for Ruby 2.6 and 2.7 (#111, #132)
 
 ### Fixed
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = version
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.homepage = 'https://github.com/braingourmets/currency_select'
   s.authors = ['Trond Arve Nordheim', 'Oliver Klee']


### PR DESCRIPTION
Ruby 2.7 is EOL now:
https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/