### PR TITLE
allow the non-formbuilder version of currency select to set the selected option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add official support for Ruby 3.2 (#125)
 
 ### Changed
-- Drop whitespace between HTML tags (#115)
 - Allow the non-formbuilder version to set the selected option (#134)
+- Drop whitespace between HTML tags (#115)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Drop whitespace between HTML tags (#115)
+- Allow the non-formbuilder version to set the selected option (#134)
 
 ### Deprecated
 

--- a/lib/to_currency_select_tag.rb
+++ b/lib/to_currency_select_tag.rb
@@ -11,9 +11,9 @@ module ActionView
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)
         value = if method(:value).arity.zero?
-                  value()
+                  options.fetch(:selected) { value() }
                 else
-                  value(object)
+                  options.fetch(:selected) { value(object) }
                 end
         content_tag(
           'select',

--- a/spec/form_options_helper_spec.rb
+++ b/spec/form_options_helper_spec.rb
@@ -7,20 +7,24 @@ require 'currency_select'
 module ActionView
   module Helpers
     describe CurrencySelectTag do
+
       let(:tag) do
         template_object = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
         CurrencySelectTag.new('user', 'currency', template_object, {})
       end
 
-      describe 'currency_select' do
-        it 'should not have a selected option' do
+      describe 'to_currency_select_tag' do
+
+        it 'should not have a selected attribute when not passing a value to be preselected' do
           expect(tag.to_currency_select_tag(nil, {}, {}).scan(/selected="selected"/).count).to eq(0)
         end
 
-        it 'should have a selected option' do
-          expect(tag.to_currency_select_tag(nil, { selected: 'XTS' }, {}).scan(/selected="selected"/).count).to eq(1)
+        it 'should have a selected attribtue when given a value to preselect' do
+          expect(tag.to_currency_select_tag(nil, {selected: 'XTS'}, {}).scan(/selected="selected"/).count).to eq(1)
         end
+
       end
+
     end
   end
 end

--- a/spec/form_options_helper_spec.rb
+++ b/spec/form_options_helper_spec.rb
@@ -7,24 +7,20 @@ require 'currency_select'
 module ActionView
   module Helpers
     describe CurrencySelectTag do
-
       let(:tag) do
         template_object = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
         CurrencySelectTag.new('user', 'currency', template_object, {})
       end
 
       describe 'to_currency_select_tag' do
-
         it 'should not have a selected attribute when not passing a value to be preselected' do
           expect(tag.to_currency_select_tag(nil, {}, {}).scan(/selected="selected"/).count).to eq(0)
         end
 
         it 'should have a selected attribtue when given a value to preselect' do
-          expect(tag.to_currency_select_tag(nil, {selected: 'XTS'}, {}).scan(/selected="selected"/).count).to eq(1)
+          expect(tag.to_currency_select_tag(nil, { selected: 'XTS' }, {}).scan(/selected="selected"/).count).to eq(1)
         end
-
       end
-
     end
   end
 end

--- a/spec/form_options_helper_spec.rb
+++ b/spec/form_options_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'action_view'
+require 'currency_select'
+
+module ActionView
+  module Helpers
+    describe CurrencySelectTag do
+
+      let(:tag) do
+        template_object = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+        CurrencySelectTag.new('user', 'currency', template_object, {})
+      end
+
+      describe 'currency_select' do
+
+        it 'should not have a selected option' do
+          expect(tag.to_currency_select_tag(nil, {}, {}).scan(/selected="selected"/).count).to eq(0)
+        end
+
+        it 'should have a selected option' do
+          expect(tag.to_currency_select_tag(nil, {selected: 'XTS'}, {}).scan(/selected="selected"/).count).to eq(1)
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/form_options_helper_spec.rb
+++ b/spec/form_options_helper_spec.rb
@@ -7,24 +7,20 @@ require 'currency_select'
 module ActionView
   module Helpers
     describe CurrencySelectTag do
-
       let(:tag) do
         template_object = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
         CurrencySelectTag.new('user', 'currency', template_object, {})
       end
 
       describe 'currency_select' do
-
         it 'should not have a selected option' do
           expect(tag.to_currency_select_tag(nil, {}, {}).scan(/selected="selected"/).count).to eq(0)
         end
 
         it 'should have a selected option' do
-          expect(tag.to_currency_select_tag(nil, {selected: 'XTS'}, {}).scan(/selected="selected"/).count).to eq(1)
+          expect(tag.to_currency_select_tag(nil, { selected: 'XTS' }, {}).scan(/selected="selected"/).count).to eq(1)
         end
-
       end
-
     end
   end
 end


### PR DESCRIPTION
as I mentioned in #133 the `FormOptionsHelper` version of `currency_select` was not respecting the user's choice of which option tag was to be selected.  This update fixes that.

In #133 I used the `.presence` method but I switched to `.fetch` since it's core Ruby.

I benchmarked between `.fetch` and `.presence` and according to `rspec-benchmark` they're basically identical.