### PR TITLE
chore(deps): allow newly released rails 7.2

### DIFF
--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   ]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_runtime_dependency 'actionview', '>= 6.1.0', '< 7.2'
+  s.add_runtime_dependency 'actionview', '>= 6.1.0', '< 8.0'
   s.add_runtime_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 6.1.2'


### PR DESCRIPTION
It was working fine during beta and rc from what I can tell so figure we can loosen up the dependency on the newly released Ruby on Rails version: https://github.com/rails/rails/releases/tag/v7.2.0