### PR TITLE
[TASK] Drop support for Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '6.1', 'ruby': '3.1.6' }
-          - { 'rails': '6.1', 'ruby': '3.2.6' }
-          - { 'rails': '6.1', 'ruby': '3.3.6' }
           - { 'rails': '7.0', 'ruby': '3.1.6' }
           - { 'rails': '7.0', 'ruby': '3.2.6' }
           - { 'rails': '7.0', 'ruby': '3.3.6' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  TargetRailsVersion: 6.1
+  TargetRailsVersion: 7.0
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop support for Rails 6.1 (#183)
+
 ### Fixed
 
 ### Security

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   ]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_dependency 'actionview', '>= 6.1.0', '< 8.1'
+  s.add_dependency 'actionview', '>= 7.0.0', '< 8.1'
   s.add_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 6.1.3'

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.1.7.6'
-
-gemspec path: '../'


### PR DESCRIPTION
Rails 6.1 is EOL.