### PR TITLE
[TASK] Drop support for Rails 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.0', 'ruby': '3.1.7' }
-          - { 'rails': '7.0', 'ruby': '3.2.8' }
-          - { 'rails': '7.0', 'ruby': '3.3.7' }
-#          - { 'rails': '7.0', 'ruby': '3.4.2' }
           - { 'rails': '7.1', 'ruby': '3.1.7' }
           - { 'rails': '7.1', 'ruby': '3.2.8' }
           - { 'rails': '7.1', 'ruby': '3.3.7' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  TargetRailsVersion: 7.0
+  TargetRailsVersion: 7.1
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop support for Rails 7.0 (#199)
+
 ### Fixed
 
 ### Security

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   ]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_dependency 'actionview', '>= 7.0.0', '< 8.1'
+  s.add_dependency 'actionview', '>= 7.1.0', '< 8.1'
   s.add_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 7.1.0'


### PR DESCRIPTION
Rails 7.0 is EOL:
https://endoflife.date/rails

Fixes #191