### PR TITLE
[TASK] Drop support for Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.1', 'ruby': '3.2.8' }
-          - { 'rails': '7.1', 'ruby': '3.3.8' }
-          - { 'rails': '7.1', 'ruby': '3.4.6' }
           - { 'rails': '7.2', 'ruby': '3.2.8' }
           - { 'rails': '7.2', 'ruby': '3.3.8' }
           - { 'rails': '7.2', 'ruby': '3.4.6' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.2
-  TargetRailsVersion: 7.1
+  TargetRailsVersion: 7.2
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 - Drop support for Ruby 3.1 (#200)
-- Drop support for Rails 7.0 (#199, #201)
+- Drop support for Rails 7.0 and 7.1 (#199, #201, #208)
 
 ### Fixed
 

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   ]
   s.extra_rdoc_files = %w[CHANGELOG.md LICENSE README.md]
 
-  s.add_dependency 'actionview', '>= 7.1.0', '< 8.1'
+  s.add_dependency 'actionview', '>= 7.2.0', '< 8.1'
   s.add_dependency 'money', '~> 6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 7.1.0'

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 7.1.0'
-
-gemspec path: '../'


### PR DESCRIPTION
Rails 7.1 will be EOL on October 1st, 2025.

https://endoflife.date/rails