### PR TITLE
[TASK] Drop support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.2', 'ruby': '3.2.10' }
           - { 'rails': '7.2', 'ruby': '3.3.10' }
           - { 'rails': '7.2', 'ruby': '3.4.9' }
           - { 'rails': '7.2', 'ruby': '4.0.2' }
-          - { 'rails': '8.0', 'ruby': '3.2.10' }
           - { 'rails': '8.0', 'ruby': '3.3.10' }
           - { 'rails': '8.0', 'ruby': '3.4.9' }
           - { 'rails': '8.0', 'ruby': '4.0.2' }
-          - { 'rails': '8.1', 'ruby': '3.2.10' }
           - { 'rails': '8.1', 'ruby': '3.3.10' }
           - { 'rails': '8.1', 'ruby': '3.4.9' }
           - { 'rails': '8.1', 'ruby': '4.0.2' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
   - rubocop-rspec_rails
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   TargetRailsVersion: 7.2
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop support for Ruby 3.2 (#230)
+
 ### Fixed
 
 ### Security

--- a/currency_select.gemspec
+++ b/currency_select.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = version
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 3.2.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.homepage = 'https://github.com/braingourmets/currency_select'
   s.authors = ['Trond Arve Nordheim', 'Oliver Klee']


### PR DESCRIPTION
Ruby 3.2 is EOL:

https://endoflife.date/ruby

Fixes #226